### PR TITLE
HTML5 for Textile

### DIFF
--- a/classTextile.php
+++ b/classTextile.php
@@ -1066,7 +1066,7 @@ class Textile
 					([^\s$f]+|\S.*?[^\s$f\n])             # content
 					([$pnct]*)                            # end
 					$f
-					($|[\]}<]|(?=[$pnct]{1,2}|\s|\)))  # tail
+					($|[\[\]}<]|(?=[$pnct]{1,2}|\s|\)))  # tail
 				/xu", array(&$this, "fSpan"), $text);
 			}
 		}


### PR DESCRIPTION
Hi Steve,

this branch uses `<abbr>` instead of `<acronym>` and substitutes align attributes to images with classes ('align-left', align-right', 'align-center'). 

The proper doctype is established at the constructor.

Cheers,

Robert
