### PR TITLE
Add support for Composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "netcarver/textile",
+    "description": "A lightweight markup language that takes (almost) plaintext and converts it into well formed HTML.",
+    "license": "BSD-3-Clause",
+    "autoload": {
+        "classmap": ["classTextile.php"]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.4-dev"
+        }
+    }
+}


### PR DESCRIPTION
This will get make the package `netcarver/textile` available via Composer. If accepted, we should get @netcarver an account on Packagist so that `netcarver/textile` will be able to be installed via Composer. I'm happy to help out with that step if needed.
## Usage

Create a `composer.json` file for a new project.

``` json
{
    "repositories": [
        {
            "type": "git",
            "url": "git://github.com/simensen/textile"
        }
    ],
    "require": {
        "netcarver/textile": "2.4.*@dev"
    }
}
```

Then run:

```
curl -s https://getcomposer.org/installer | php
php composer.phar install
```

At this point, a simple test PHP file can be created and the following should work:

``` php
<?php
require 'vendor/autoload.php';
$textile = new Textile;
$output = $textile->TextileThis('h1. Hello World!');
print $output . "\n";
```
### Packagist

By getting `netcarver/textile` on Packagist, the `composer.json` would be able to look like this:

``` json
{
    "require": {
        "netcarver/textile": "2.4.*@dev"
    }
}
```
