### PR TITLE
PCRE named groups incompatibility breaks parseURI()

### DIFF
--- a/classTextile.php
+++ b/classTextile.php
@@ -1484,7 +1484,7 @@ class Textile
 	 **/
 	function parseURI( $uri, &$m )
 	{
-		$r = "@^((?<scheme>[^:/?#]+):)?(//(?<authority>[^/?#]*))?(?<path>[^?#]*)(\?(?<query>[^#]*))?(#(?<fragment>.*))?@";
+		$r = "@^((?P<scheme>[^:/?#]+):)?(//(?P<authority>[^/?#]*))?(?P<path>[^?#]*)(\?(?P<query>[^#]*))?(#(?P<fragment>.*))?@";
 		#       12                     3  4                      5              6  7                8 9
 		#
 		#	scheme    = $2


### PR DESCRIPTION
Apparently, there's a PCRE version around even with PHP 5.3+ which does not support named groups via the `(?<group>)` syntax but does support the Perl-compatible one `(?P<group>)`.

See this bug  report: http://forum.textpattern.com/viewtopic.php?pid=265288#p265288

Related: https://github.com/cakephp/cakephp/pull/681

This branch uses the latter syntax which seems to be commonly supported. Needs testing.
