### PR TITLE
fix undefined offset on strict mode

### DIFF
--- a/classTextile.php
+++ b/classTextile.php
@@ -1848,7 +1848,7 @@ class Textile
 // -------------------------------------------------------------
 	function fTextile($m)
 	{
-		@list(, $before, $notextile, $after) = $m;
+		@list(, $before, $notextile, $after) = array_pad($m, 4, null);
 		#$notextile = str_replace(array_keys($modifiers), array_values($modifiers), $notextile);
 		return $before.$this->shelve($notextile).$after;
 	}


### PR DESCRIPTION
textile code like :
=.=.= 
(remove . between =)
=.=.=.=

generate error in strict mode (undefined offset).
use of array_pad to avoid that. (it's maybe also a good idea to apply array_pad on all list() in this class)
