### PR TITLE
Allow inline links like "test?param[]=value"

### DIFF
--- a/classTextile.php
+++ b/classTextile.php
@@ -1549,6 +1549,7 @@ class Textile
 // -------------------------------------------------------------
 	function links($text)
 	{
+		$urlCharTerminator = '\['; // Chars to avoid on an url end to allow links like "test?param[]=value"
 		return preg_replace_callback('/
 			(^|(?<=[\s>.\(])|[{[]) # $pre
 			"                      # start
@@ -1556,9 +1557,9 @@ class Textile
 			([^"]+?)               # $text
 			(?:\(([^)]+?)\)(?="))? # $title
 			":
-			('.$this->urlch.'+?)   # $url
+			('.$this->urlch.'+?[^'.$urlCharTerminator.'])   # $url
 			(\/)?                  # $slash
-			([^'.$this->regex_snippets['wrd'].'\/;]*?)  # $post
+			([^'.$this->regex_snippets['wrd'].'\/;'.$urlCharTerminator.']*?)  # $post
 			([\]}]|(?=\s|$|\)))	   # $tail
 			/x'.$this->regex_snippets['mod'], array(&$this, "fLink"), $text);
 	}


### PR DESCRIPTION
Tested with the following textile snippets:

Syntax that should work still after the patch:

```
Try it out on "github":http://github.com.

...blah blah (for more details look on "github":http://github.com) blah blah...

...blah blah [for more details look on "github":http://github.com] blah blah...

...blah blah[^["on github":http://github.com]^] blah...

...blah blah ^["on github":http://github.com]^ blah...
```

Syntax that did not work before:

```
"my link":http://github.com?param[]=value

In a sentence "my link":http://github.com?param[]=value.

In a sentence "my link":http://github.com?param[].

...blah blah ^["on github":http://github.com?param[]]^ blah...
```
