### PR TITLE
avoid double html encoding 

### DIFF
--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -2511,19 +2511,8 @@ class Parser
      **/
     protected function encodeHTML($str, $quotes=1)
     {
-        $a = array(
-            '&' => '&amp;',
-            '<' => '&lt;',
-            '>' => '&gt;',
-        );
-        if ($quotes) {
-            $a = $a + array(
-                "'" => '&#39;', // Numeric, as in htmlspecialchars
-                '"' => '&quot;',
-            );
-        }
-
-        return str_replace(array_keys($a), $a, $str);
+        $quote = ( $quotes ) ? ENT_QUOTES : ENT_NOQUOTES;
+  	    return htmlspecialchars($str, $quote, 'UTF-8', false);	
     }
 
 


### PR DESCRIPTION
if tags in the textile string is already encoded it will be reencoded in code block:
@ 
  &lt;div&gt; oo &lt;/div&gt;
@
become:
<code>&amp;lt;div&amp;gt; oo &amp;lt;/div&amp;gt;</code>

this change avoid double encoding
