### PR TITLE
Fixing a regexp to proper handling of block elements, which don't have a space after dot

### DIFF
--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -1617,7 +1617,7 @@ class Parser
 
         foreach ($text as $line) {
             $anon = 0;
-            if (preg_match("/^($blocktags)($this->a$this->c)\.(\.?)(?::(\S+))?(.*)$/Ss", $line, $m)) {
+            if (preg_match("/^($blocktags)($this->a$this->c)\.(\.?)(?::(\S+))? ?(.*)$/Ss", $line, $m)) {
                 // Last block was extended, so close it
                 if ($ext) {
                     $out[count($out)-1] .= $c1;


### PR DESCRIPTION
This wasn't handled correctly:
`bq.Some text`

This change makes PHP and JS versions of Textile compatible.
JS-version I was testing: http://borgar.github.com/textile-js/
