### PR TITLE
Suggested fix for issue #175

### DIFF
--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -2188,7 +2188,6 @@ class Parser
                 }
             }
 
-            
             $o['style'] = trim(str_replace(array("\n", ';;'), array('', ';'), $so));
         }
 

--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -2029,7 +2029,7 @@ class Parser
 
     protected function parseAttribsToArray($in, $element = '', $include_id = true, $autoclass = '')
     {
-        $style = '';
+        $style = array();
         $class = '';
         $lang = '';
         $colspan = '';
@@ -2166,7 +2166,7 @@ class Parser
             $o['span'] = $this->cleanAttribs($span);
         }
 
-        if ($style) {
+        if (!empty($style)) {
             $so = '';
             $tmps = array();
 
@@ -2188,8 +2188,8 @@ class Parser
                 }
             }
 
-            $style = trim(str_replace(array("\n", ';;'), array('', ';'), $so));
-            $o['style'] = $style;
+            
+            $o['style'] = trim(str_replace(array("\n", ';;'), array('', ';'), $so));
         }
 
         if ($width) {


### PR DESCRIPTION
As described in the issue (#175), initializing $style in Parser::parseAttribsToArray as a string and then using it as an array seems to cause an error (let alone being not the best coding style I guess).

I suggest initializing and using $style only as an array and created this commit accordingly.