### PR TITLE
Trim Dean's email address

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2003-2004, Dean Allen <dean@textism.com>
+Copyright (c) 2003-2004, Dean Allen
 All rights reserved.
 
 Thanks to Carlo Zottmann <carlo@g-blog.net> for refactoring

--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -9,7 +9,7 @@
 /*
  * Textile - A Humane Web Text Generator
  *
- * Copyright (c) 2003-2004, Dean Allen <dean@textism.com>
+ * Copyright (c) 2003-2004, Dean Allen
  * All rights reserved.
  *
  * Thanks to Carlo Zottmann <carlo@g-blog.net> for refactoring

--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -65,8 +65,8 @@ Block modifier syntax:
     Example: bq. Block quotation... -> <blockquote>Block quotation...</blockquote>
 
     Blockquote with citation: bq.:http://citation.url
-    Example: bq.:http://textism.com/ Text...
-    ->    <blockquote cite="http://textism.com">Text...</blockquote>
+    Example: bq.:http://example.com/ Text...
+    ->    <blockquote cite="http://example.com">Text...</blockquote>
 
     Footnote: fn(1-100).
     Example: fn1. Footnote... -> <p id="fn1">Footnote...</p>


### PR DESCRIPTION
### Type of change
<!--- Put an `x` in all the boxes that apply. -->
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Security fix
- [X] Other

### Description

Remove Dean Cameron's (defunct) email address, replace references to textism.com with example.com

### Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I documented my additions and changes using PHPdoc.
- [ ] I wrote fixtures to cover my additions.
- [ ] `$ composer update`
- [ ] `$ composer test`
- [ ] `$ composer cs`