### PR TITLE
Fix textile two link issue in Asia languages.

### DIFF
--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -4216,8 +4216,22 @@ class Parser
 
     protected function replaceLinks($text)
     {
-        $stopchars = "\s|^'\"*[";
-
+        $stopchars = "\s|^'\"*";
+        $result = preg_replace_callback(
+            '/
+            (?P<pre>\[)                     # Optionally open with a square bracket eg. Look ["here":url]
+            '.$this->uid.'linkStartMarker:" # marks start of the link
+            (?P<inner>(?:.|\n)*?)           # grab the content of the inner "..." part of the link, can be anything but
+                                            # do not worry about matching class, id, lang or title yet
+            ":                              # literal ": marks end of atts + text + title block
+            (?P<urlx>[^'.$stopchars.']*])    # url upto a stopchar
+            /x'.$this->regex_snippets['mod'],
+            array($this, "fLink"),
+            $text
+        );
+        if ($result !== $text) {
+            return $result;
+        }
         return (string)preg_replace_callback(
             '/
             (?P<pre>\[)?                    # Optionally open with a square bracket eg. Look ["here":url]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
The function "replaceLinks" didn't work if one link followed another without a white space between them, this always happens in Chinese Language. I added a char '[' in stop characters to fix this.

<!--- Please replace `{Please write here}` with your answers as best you can. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### Type of change
<!--- Put an `x` in all the boxes that apply. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Security fix

### Description
<!--- Describe your changes in detail. -->
For example, there are two links without a white space between them.

[中文](https://github.com/textile/php-textile)[链接](https://github.com/kaffa/php-textile) 

The code in textile-lang would be:
```text
["中文":link1]["链接":link2]

[link1]https://github.com/textile/php-textile
[link2]https://github.com/kaffa/php-textile
```

Another example in English.

The subject text is 
```
["a":link1]["a":link1]

[link1]https://alternativeto.cn
```
The $text in *replaceLinks* is:
```text
[textileRef:7284512575e11360f53ded:linkStartMarker:"a":link1][textileRef:7284512575e11360f53ded:linkStartMarker:"a":link1]
```
The regular expression in *replaceLinks* function:
```php
(?P<pre>\[)?textileRef:7284512575e11360f53ded:linkStartMarker:"(?P<inner>(?:.|\n)*?)":(?P<urlx>[^\s|^'"*]*)
```
The preg_replace_callback can only handle the first link above, because it matches the link in greedy mode, the match is 
```
[textileRef:7284512575e11360f53ded:linkStartMarker:"a":link1][textileRef:7284512575e11360f53ded:linkStartMarker:
```
Then the second breaks because of no match. 

The sample code to show this issue:
```
<?php
require '../vendor/autoload.php';
$parser = new \Netcarver\Textile\Parser();

echo $parser->parse('
["a":link1]["a":link1]

[link1]https://alternativeto.cn
');

echo $parser->parse('
["中文":link1]["链接":link2]

[link1]https://github.com/textile/php-textile
[link2]https://github.com/kaffa/php-textile
');
```

### Checklist

<!--- Put an `x` in all the boxes that apply. -->
- [ ] I documented my additions and changes using PHPdoc.
- [x] I wrote fixtures to cover my additions.
- [ ] `$ composer update`
- [ ] `$ composer test`
- [ ] `$ composer cs`
