### PR TITLE
Update Parser.php to fix two inline links issue

### DIFF
--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -4216,8 +4216,22 @@ class Parser
 
     protected function replaceLinks($text)
     {
-        $stopchars = "\s|^'\"*[";
-
+        $stopchars = "\s|^'\"*";
+        $result = preg_replace_callback(
+            '/
+            (?P<pre>\[)                     # Optionally open with a square bracket eg. Look ["here":url]
+            '.$this->uid.'linkStartMarker:" # marks start of the link
+            (?P<inner>(?:.|\n)*?)           # grab the content of the inner "..." part of the link, can be anything but
+                                            # do not worry about matching class, id, lang or title yet
+            ":                              # literal ": marks end of atts + text + title block
+            (?P<urlx>[^'.$stopchars.']*])    # url upto a stopchar
+            /x'.$this->regex_snippets['mod'],
+            array($this, "fLink"),
+            $text
+        );
+        if ($result !== $text) {
+            return $result;
+        }
         return (string)preg_replace_callback(
             '/
             (?P<pre>\[)?                    # Optionally open with a square bracket eg. Look ["here":url]

--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -4217,7 +4217,7 @@ class Parser
     protected function replaceLinks($text)
     {
         $stopchars = "\s|^'\"*";
-        $result = preg_replace_callback(
+        $text = preg_replace_callback(
             '/
             (?P<pre>\[)                     # Optionally open with a square bracket eg. Look ["here":url]
             '.$this->uid.'linkStartMarker:" # marks start of the link
@@ -4229,9 +4229,6 @@ class Parser
             array($this, "fLink"),
             $text
         );
-        if ($result !== $text) {
-            return $result;
-        }
         return (string)preg_replace_callback(
             '/
             (?P<pre>\[)?                    # Optionally open with a square bracket eg. Look ["here":url]

--- a/test/fixtures/issue-202.yaml
+++ b/test/fixtures/issue-202.yaml
@@ -1,0 +1,10 @@
+Link with square brackets directly followed by words or link will be broken at the second link:
+  input: |
+    ["Wikipedia":https://en.wikipedia.org/]["Github":https://www.github.com/]
+
+    我爱["Textile":https://textile-lang.com/]和["TextPattern":https://textpattern.com/]
+
+  expect: |
+    <p><a href="https://en.wikipedia.org/">Wikipedia</a><a href="https://www.github.com/">Github</a></p>
+
+    <p>我爱<a href="https://textile-lang.com/">Textile</a>和<a href="https://textpattern.com/">TextPattern</a></p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Please replace `{Please write here}` with your answers as best you can. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### Type of change
<!--- Put an `x` in all the boxes that apply. -->
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Security fix

### Description
<!--- Describe your changes in detail. -->

Input:
```
I love ["Textile":https://textile-lang.com/] and ["TextPattern":https://textpattern.com/]
```
Output as Expected:
```
<p>I love <a href="https://textile-lang.com/">Textile</a> and <a href="https://textpattern.com/">TextPattern</a></p>
```

but there's no white space character between words, I wish I could find a way to parse them.

Input:
```
我爱["Textile":https://textile-lang.com/]和["TextPattern":https://textpattern.com/]
```
Expected:
```
<p>我爱<a href="https://textile-lang.com/">Textile</a>和<a href="https://textpattern.com/">TextPattern</a></p>
```
Output:
```
<p>我爱<a href="https://textile-lang.com/">Textile</a>和[textileRef:5237512785e14c359cf3c5:linkStartMarker:&#8220;TextPattern&#8221;:https://textpattern.com/]</p>
```

There is no white space character between links and words in Chinese language. And the square brackets should be a pair, the code I modified will match the square brackets pairs first.

### Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I documented my additions and changes using PHPdoc.
- [ ] I wrote fixtures to cover my additions.
- [ ] `$ composer update`
- [ ] `$ composer test`
- [ ] `$ composer cs`
