### PR TITLE
Support consecutive links

### DIFF
--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -4217,19 +4217,29 @@ class Parser
     protected function replaceLinks($text)
     {
         $stopchars = "\s|^'\"*";
+        $needle = $this->uid . 'linkStartMarker:';
+        $prev = null;
 
-        return (string)preg_replace_callback(
-            '/
-            (?P<pre>\[)?                    # Optionally open with a square bracket eg. Look ["here":url]
-            '.$this->uid.'linkStartMarker:" # marks start of the link
-            (?P<inner>(?:.|\n)*?)           # grab the content of the inner "..." part of the link, can be anything but
-                                            # do not worry about matching class, id, lang or title yet
-            ":                              # literal ": marks end of atts + text + title block
-            (?P<urlx>[^'.$stopchars.']*)    # url upto a stopchar
-            /x'.$this->regex_snippets['mod'],
-            array($this, "fLink"),
-            $text
-        );
+        while (\strpos($text, $needle) !== false) {
+            $text = (string)preg_replace_callback(
+                '/
+                (?P<pre>\[)?
+                ' . $needle . '"
+                (?P<inner>(?:.|\n)*?)
+                ":(?P<urlx>[^' . $stopchars . ']*)
+                /x' . $this->regex_snippets['mod'],
+                array($this, "fLink"),
+                $text
+            );
+
+            if ($prev === $text) {
+                break;
+            }
+
+            $prev = $text;
+        }
+
+        return $text;
     }
 
     /**

--- a/test/fixtures/issue-202.yaml
+++ b/test/fixtures/issue-202.yaml
@@ -1,0 +1,20 @@
+Links placed one after other should be parsed:
+  input: |
+    ["1":https://example.tld]["2":https://example.tld]["3":https://example.tld]
+
+  expect: |
+    <p><a href="https://example.tld">1</a><a href="https://example.tld">2</a><a href="https://example.tld">3</a></p>
+
+Continous non-breaking content between links should be allowed:
+  input: |
+    ["1":https://example.tld]|["2":https://example.tld]|["3":https://example.tld]
+
+  expect: |
+    <p><a href="https://example.tld">1</a>|<a href="https://example.tld">2</a>|<a href="https://example.tld">3</a></p>
+
+Same applies for continuous multi-byte characters between links:
+  input: |
+    我["1":https://example.tld/]和["2":https://example.tld/]和["3":https://example.tld/]
+
+  expect: |
+    <p>我<a href="https://example.tld/">1</a>和<a href="https://example.tld/">2</a>和<a href="https://example.tld/">3</a></p>


### PR DESCRIPTION
Allows placing links one after other.

Fixes #202 
Closes #205

Thanks @kaffa

<!--- Provide a general summary of your changes in the title above. -->

<!--- Please replace `{Please write here}` with your answers as best you can. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### Type of change
<!--- Put an `x` in all the boxes that apply. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Security fix

### Description
<!--- Describe your changes in detail. -->

{Please write here}

### Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] I documented my additions and changes using PHPdoc.
- [x] I wrote fixtures to cover my additions.
- [x] `$ composer update`
- [x] `$ composer test`
- [x] `$ composer cs`
