### PR TITLE
Fixes issue where the parser was breaking URLs that contains equal sign

### DIFF
--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -4049,7 +4049,7 @@ class Parser
             } else {
                 $pp = explode('/', $parts['path']);
                 foreach ($pp as &$p) {
-                    $p = str_replace(array('%25', '%40'), array('%', '@'), rawurlencode($p));
+                    $p = str_replace(array('%25', '%40','%3D'), array('%', '@','='), rawurlencode($p));
                     if (!in_array($parts['scheme'], array('mailto'))) {
                         $p = str_replace('%2B', '+', $p);
                     }


### PR DESCRIPTION
Fixes broken URL when the input is:

```
"test":https://www.payscale.com/research/US/Degree=Bachelor%27s_Degree%2C_Business_Administration/Salary
```

Which resulted in

```html
<a href="https://www.payscale.com/research/US/Degree%3DBachelor%27s_Degree%2C_Business_Administration/Salary" rel="noopener noreferrer" target="_blank">test</a>
```

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Security fix

### Description

Which is a different URL, technically I guess it's arguable that in this case, Payscale site could work around that on their end, but I guess it would be good to aim to change as little as possible the given URLs, nowadays an equal sign on most URLs is harmless but changing it could break several URLs that aren't so well handled on the server-side.

### Checklist
- [ ] I documented my additions and changes using PHPdoc.
- [ ] I wrote fixtures to cover my additions.
- [ ] `$ composer update`
- [ ] `$ composer test`
- [ ] `$ composer cs`

This is my first contribution to this project, so is there some contribute file that could show how should I organize and cover fixtures? 

Also which is the ideal PHP version to use to dev this project? I tried running composer test and composer cs here but both failed.