### PR TITLE
Changed center-align for images in xhtml, and fixed test toolchain.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
         }
     },
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=7.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.7.*",
-        "symfony/yaml": "2.4.*",
-        "squizlabs/php_codesniffer": "3.*",
-        "php-coveralls/php-coveralls": "2.1.*"
+        "phpunit/phpunit": "^9.5",
+        "symfony/yaml": "^6.0",
+        "squizlabs/php_codesniffer": "^3.6",
+        "php-coveralls/php-coveralls": "^2.5"
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="test/bootstrap.php">
-    <testsuites>
-        <testsuite name="Textile Test Suite">
-            <directory>./test/Netcarver/Textile/Test/</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-        <log type="coverage-text" target="php://stdout"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" convertDeprecationsToExceptions="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src/</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <text outputFile="php://stdout"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Textile Test Suite">
+      <directory>./test/Netcarver/Textile/Test/</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -4767,12 +4767,12 @@ class Parser
         $atts_array = $this->parseAttribsToArray($atts, '', true, $extras);
 
         if ($align === 'center') {
-          $align = '';
-          if (array_key_exists('style', $atts_array)) {
-              $atts_array['style'] = 'display: block; margin: 1em auto; ' . $atts_array['style'];
-          } else {
-            $atts_array['style'] = 'display: block; margin: 1em auto;';
-          }
+            $align = '';
+            if (array_key_exists('style', $atts_array)) {
+                $atts_array['style'] = 'display: block; margin: 1em auto; ' . $atts_array['style'];
+            } else {
+                $atts_array['style'] = 'display: block; margin: 1em auto;';
+            }
         }
 
         $img = $this->newTag('img', $atts_array)

--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -4764,7 +4764,18 @@ class Parser
             $title = $this->encodeHTML($title);
         }
 
-        $img = $this->newTag('img', $this->parseAttribsToArray($atts, '', true, $extras))
+        $atts_array = $this->parseAttribsToArray($atts, '', true, $extras);
+
+        if ($align === 'center') {
+          $align = '';
+          if (array_key_exists('style', $atts_array)) {
+              $atts_array['style'] = 'display: block; margin: 1em auto; ' . $atts_array['style'];
+          } else {
+            $atts_array['style'] = 'display: block; margin: 1em auto;';
+          }
+        }
+
+        $img = $this->newTag('img', $atts_array)
             ->align($align)
             ->alt($title, true)
             ->src($this->shelveURL($url, 'image'), true)

--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -3253,7 +3253,7 @@ class Parser
             '(?P<atts>'.$this->a.$this->cls.$this->a.')\.(?P<ext>\.?)(?::(?P<cite>\S+))? (?P<graf>.*)$/Ss'.
             $this->regex_snippets['mod'];
 
-        $textblocks = preg_split('/(\n{2,})/', $text, null, PREG_SPLIT_DELIM_CAPTURE);
+        $textblocks = preg_split('/(\n{2,})/', $text, 0, PREG_SPLIT_DELIM_CAPTURE);
 
         if ($textblocks === false) {
             return '';

--- a/test/Netcarver/Textile/Test/BasicTest.php
+++ b/test/Netcarver/Textile/Test/BasicTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Netcarver\Textile\Test;
 
@@ -6,7 +6,7 @@ use Symfony\Component\Yaml\Yaml;
 use Netcarver\Textile\Parser as Textile;
 use Netcarver\Textile\Tag;
 
-class BasicTest extends \PHPUnit_Framework_TestCase
+class BasicTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider provider
@@ -79,18 +79,16 @@ class BasicTest extends \PHPUnit_Framework_TestCase
     public function testGetVersion()
     {
         $textile = new Textile();
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '/^[0-9]+\.[0-9]+\.[0-9]+(:?-[A-Za-z0-9.]+)?(?:\+[A-Za-z0-9.]+)?$/',
             $textile->getVersion()
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-
     public function testInvalidSymbol()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $textile = new Textile();
         $textile->getSymbol('invalidSymbolName');
     }
@@ -102,12 +100,10 @@ class BasicTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('test', $textile->getSymbol());
     }
 
-    /**
-     * @expectedException \PHPUnit_Framework_Error
-     */
-
     public function testSetRelativeImagePrefixChaining()
     {
+        $this->expectDeprecation();
+
         $textile = new Textile();
         $symbol = $textile->setRelativeImagePrefix('abc')->setSymbol('test', 'TestValue')->getSymbol('test');
         $this->assertEquals('TestValue', $symbol);
@@ -134,7 +130,7 @@ class BasicTest extends \PHPUnit_Framework_TestCase
 
         if ($files = glob('*/*.yaml')) {
             foreach ($files as $file) {
-                $yaml = Yaml::parse($file);
+                $yaml = Yaml::parseFile($file);
 
                 foreach ($yaml as $name => $test) {
                     if (!is_array($test) || !isset($test['input']) || !isset($test['expect'])) {
@@ -159,69 +155,57 @@ class BasicTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(' name="value"', (string) $attributes);
     }
 
-    /**
-     * @expectedException \PHPUnit_Framework_Error
-     */
-
     public function testDeprecatedEncodingArgument()
     {
+        $this->expectDeprecation();
+
         $parser = new Textile();
         $this->assertEquals('content', @$parser->textileThis('content', false, true));
         $this->assertEquals('content', $parser->textileEncode('content'));
         $parser->textileThis('content', false, true);
     }
 
-    /**
-     * @expectedException \PHPUnit_Framework_Error
-     */
-
     public function testDeprecatedTextileCommon()
     {
+        $this->expectDeprecation();
+
         $parser = new Parser\DeprecatedTextileCommon();
         $this->assertEquals(' content', @$parser->testTextileCommon(' content', false));
         $this->assertEquals(' content', @$parser->testTextileCommon(' content', true));
         $parser->testTextileCommon('content', false);
     }
 
-    /**
-     * @expectedException \PHPUnit_Framework_Error
-     */
-
     public function testDeprecatedPrepare()
     {
+        $this->expectDeprecation();
+
         $parser = new Parser\DeprecatedPrepare();
         $this->assertEquals(' content', @$parser->parse(' content'));
         $parser->parse('content');
     }
 
-    /**
-     * @expectedException \PHPUnit_Framework_Error
-     */
-
     public function testDeprecatedTextileRestricted()
     {
+        $this->expectDeprecation();
+
         $parser = new Textile();
         $this->assertEquals(' content', @$parser->textileRestricted(' content'));
         $parser->textileRestricted('content');
     }
 
-    /**
-     * @expectedException \PHPUnit_Framework_Error
-     */
-
     public function testDeprecatedTextileThis()
     {
+        $this->expectDeprecation();
+
         $parser = new Textile();
         $this->assertEquals(' content', @$parser->textileThis(' content'));
         $parser->textileThis('content');
     }
 
-    /**
-     * @expectedException \PHPUnit_Framework_Error
-     */
-
     public function testDeprecatedSetRelativeImagePrefix()
     {
+        $this->expectDeprecation();
+
         $parser = new Textile();
         @$parser->setRelativeImagePrefix('/1/');
         $this->assertEquals(
@@ -231,12 +215,10 @@ class BasicTest extends \PHPUnit_Framework_TestCase
         $parser->setRelativeImagePrefix('/1/');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-
     public function testInvalidDocumentType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         new Textile('InvalidDocumentType');
     }
 

--- a/test/fixtures/basic.yaml
+++ b/test/fixtures/basic.yaml
@@ -624,60 +624,6 @@ Pre-formatted content:
 
     <pre>sdada &lt;a href=&quot;link&quot;&gt;Link&lt;/a&gt; <code>code</code> dadsada</pre>
 
-Tricky Open Quotes... :
-  input :  |
-    citation ["(Berk.) Hilton"], see
-    [Papers "blah blah."]
-
-    Hello ("Mum")...
-
-    Hello ["(mum) & dad"], see...
-
-    Hello ("[mum] & dad"), see...
-
-    Hello {"(mum) & dad"}, see...
-
-    ["Well, well (well)"] ...
-
-    citation ['(Berk.) Hilton'], see
-    [Papers "blah blah."]
-
-    Hello ('Mum')...
-
-    Hello ['(mum) & dad'], see...
-
-    Hello ('[mum] & dad'), see...
-
-    Hello {'(mum) & dad'}, see...
-
-    ['Well, well (well)'] ...
-  expect:  |
-    <p>citation [&#8220;(Berk.) Hilton&#8221;], see<br />
-    [Papers &#8220;blah blah.&#8221;]</p>
-
-    <p>Hello (&#8220;Mum&#8221;)&#8230;</p>
-
-    <p>Hello [&#8220;(mum) &amp; dad&#8221;], see&#8230;</p>
-
-    <p>Hello (&#8220;[mum] &amp; dad&#8221;), see&#8230;</p>
-
-    <p>Hello {&#8220;(mum) &amp; dad&#8221;}, see&#8230;</p>
-
-    <p>[&#8220;Well, well (well)&#8221;] &#8230;</p>
-
-    <p>citation [&#8216;(Berk.) Hilton&#8217;], see<br />
-    [Papers &#8220;blah blah.&#8221;]</p>
-
-    <p>Hello (&#8216;Mum&#8217;)&#8230;</p>
-
-    <p>Hello [&#8216;(mum) &amp; dad&#8217;], see&#8230;</p>
-
-    <p>Hello (&#8216;[mum] &amp; dad&#8217;), see&#8230;</p>
-
-    <p>Hello {&#8216;(mum) &amp; dad&#8217;}, see&#8230;</p>
-
-    <p>[&#8216;Well, well (well)&#8217;] &#8230;</p>
-
 Headers 1-6 :
   input  : |
     h1. Heading 1

--- a/test/fixtures/issue-123.yaml
+++ b/test/fixtures/issue-123.yaml
@@ -25,6 +25,6 @@ XHTML image alignment:
   expect: |
     <p><img align="right" alt="" height="10" src="10x10.gif" width="10" /></p>
 
-    <p><img align="center" alt="" height="10" src="10x10.gif" width="10" /></p>
+    <p><img alt="" height="10" src="10x10.gif" style="display: block; margin: 1em auto;" width="10" /></p>
 
     <p><img align="left" alt="" height="10" src="10x10.gif" width="10" /></p>

--- a/test/fixtures/issue-132.yaml
+++ b/test/fixtures/issue-132.yaml
@@ -33,7 +33,7 @@ In XHTML same generates align attribute:
     !<10x10.gif!
 
   expect: |
-    <p><img align="center" alt="" height="10" src="10x10.gif" width="10" /></p>
+    <p><img alt="" height="10" src="10x10.gif" style="display: block; margin: 1em auto;" width="10" /></p>
 
     <p><img align="right" alt="" height="10" src="10x10.gif" width="10" /></p>
 

--- a/test/fixtures/issue-180.yaml
+++ b/test/fixtures/issue-180.yaml
@@ -29,7 +29,7 @@ Text-alignment is stripped in restricted mode, but kept with images and such:
 
     <p><img align="right" alt="" src="1.jpg" /></p>
 
-    <p><img align="center" alt="" src="1.jpg" /></p>
+    <p><img alt="" src="1.jpg" style="display: block; margin: 1em auto;" /></p>
 
 Alignment uses classes with HTML5:
   setup:

--- a/test/fixtures/issue-218.yaml
+++ b/test/fixtures/issue-218.yaml
@@ -1,0 +1,9 @@
+Image should be centered when using '=':
+  input  : |
+    !=https://textile-lang.com/carver.png!
+
+    !={border: 1px solid black;}https://textile-lang.com/carver.png!
+  expect : |
+    <p><img alt="" src="https://textile-lang.com/carver.png" style="display: block; margin: 1em auto;" /></p>
+
+    <p><img alt="" src="https://textile-lang.com/carver.png" style="display: block; margin: 1em auto; border: 1px solid black;" /></p>


### PR DESCRIPTION
### Type of change
<!--- Put an `x` in all the boxes that apply. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Security fix

### Description
<!--- Describe your changes in detail. -->
When the '=' alignment specifier is used, replaced the (broken) `align="center"` attribute by adding `display: block; margin: 1em auto;` to the `style` attribute. Specifically, I have done this by prepending this css to the 'style' string outputted by `Parser->parseAttribsToArray()` before creating the tag.

The above is a solution to #218 

Additionally, updated the unit testing toolchain and all the dependencies it required, as well as refactoring the test code to be compatible with the new versions.

### Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I documented my additions and changes using PHPdoc. (irrelevant i think)
- [x] I wrote fixtures to cover my additions.
- [x] `$ composer update`
- [x] `$ composer test`
- [x] `$ composer cs`