### PR TITLE
Doctype-specific self-closing tags

### DIFF
--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -1994,7 +1994,7 @@ class Parser
         $text = $this->retrieveTags($text);
         $text = $this->retrieveURLs($text);
 
-        $text = preg_replace("~<br[ ]*/?>~i", $this->getLineBreak()."\n", $text);
+        $text = (string) preg_replace("~<br[ ]*/?>~i", $this->getLineBreak()."\n", $text);
 
         return $text;
     }

--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -1990,12 +1990,12 @@ class Parser
      * Parses the given Textile input in un-restricted mode.
      *
      * This method is deprecated, use Parser::parse() method instead.
-     * This method is equilavent of:
+     * This method is equivalent of:
      *
      * bc. $parser = new \Netcarver\Textile\Parser();
      * echo $parser->parse('h1. Hello World!');
      *
-     * Additinal arguments can be passed with setter methods:
+     * Additional arguments can be passed with setter methods:
      *
      * bc. $parser = new \Netcarver\Textile\Parser();
      * echo $parser
@@ -2380,7 +2380,7 @@ class Parser
      * Cleans a HTML attribute value.
      *
      * This method checks for presence of URL encoding in the value.
-     * If the number encoded characters exceeds the thereshold,
+     * If the number encoded characters exceeds the threshold,
      * the input is discarded. Otherwise the encoded
      * instances are decoded.
      *
@@ -2424,7 +2424,7 @@ class Parser
      *
      * @param string $name The HTML element name
      * @param array<string, int|string> $atts HTML attributes applied to the tag
-     * @param bool $selfclosing Determines if the tag should be selfclosing
+     * @param bool $selfclosing Determines if the tag should be self-closing
      * @return Tag
      */
     protected function newTag($name, $atts, $selfclosing = true)

--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -1993,7 +1993,7 @@ class Parser
         $text = $this->retrieveTags($text);
         $text = $this->retrieveURLs($text);
 
-        $text = (string) preg_replace("~<br[ ]*/?>~i", $this->getLineBreak()."\n", $text);
+        $text = str_replace($this->getLineBreak(), $this->getLineBreak()."\n", $text);
 
         return $text;
     }

--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -1211,9 +1211,8 @@ class Parser
      * @return string The break tag
      * @since  3.8.0
      * @see    Parser::getDocumentType()
-     * @api
      */
-    public function getLineBreak()
+    protected function getLineBreak()
     {
         return ($this->getDocumentType() === self::DOCTYPE_HTML5) ? '<br>' : '<br />';
     }

--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -3314,7 +3314,7 @@ class Parser
                 }
             }
 
-            $block = $whitespace . $this->doPBr($block);
+            $block = $whitespace . $this->doPBr((string) $block);
             if ($this->getDocumentType() === self::DOCTYPE_XHTML) {
                 $block = str_replace('<br>', '<br />', $block);
             }

--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -1215,7 +1215,7 @@ class Parser
      */
     public function getLineBreak()
     {
-        return ($this->getDocumentType() === 'html5') ? '<br>' : '<br />';
+        return ($this->getDocumentType() === self::DOCTYPE_HTML5) ? '<br>' : '<br />';
     }
 
     /**
@@ -2442,7 +2442,7 @@ class Parser
      */
     protected function newTag($name, $atts, $selfclosing = true)
     {
-        return new Tag($name, $atts, $selfclosing && $this->getDocumentType() !== 'html5');
+        return new Tag($name, $atts, $selfclosing && $this->getDocumentType() !== self::DOCTYPE_HTML5);
     }
 
     /**
@@ -3316,7 +3316,7 @@ class Parser
             }
 
             $block = $whitespace . $this->doPBr($block);
-            if ($this->getDocumentType() === 'xhtml') {
+            if ($this->getDocumentType() === self::DOCTYPE_XHTML) {
                 $block = str_replace('<br>', '<br />', $block);
             }
 

--- a/src/Netcarver/Textile/Tag.php
+++ b/src/Netcarver/Textile/Tag.php
@@ -111,7 +111,7 @@ class Tag extends DataBag
         }
 
         if ($this->tag) {
-            return '<' . $this->tag . $attributes . (($this->selfclose) ? " />" : '>');
+            return '<' . $this->tag . $attributes . (($this->selfclose) ? ' />' : '>');
         }
 
         return $attributes;

--- a/test/fixtures/basic.yaml
+++ b/test/fixtures/basic.yaml
@@ -3500,3 +3500,71 @@ Link and image encoding :
     <p><a href="http://example.com/?foo&amp;amp;bar">Entity is merely part of text</a></p>
 
     <p><a href="http://example.com/%26.html">In path component</a></p>
+
+Self-closing tag endings in XHTML doctype :
+  input:  |
+    This is a multiline
+    text block split by
+    manual line breaks
+
+    - Multiline
+    - text block
+    - with dashes
+    - (not bullets)
+
+    !http://textpattern.com/favicon.ico!
+
+    !<http://textpattern.com/favicon.ico!
+
+    !>http://textpattern.com/favicon.ico!
+
+  expect : |
+    <p>This is a multiline<br />
+    text block split by<br />
+    manual line breaks</p>
+
+    <p>- Multiline<br />
+    - text block<br />
+    - with dashes<br />
+    - (not bullets)</p>
+
+    <p><img alt="" src="http://textpattern.com/favicon.ico" /></p>
+
+    <p><img align="left" alt="" src="http://textpattern.com/favicon.ico" /></p>
+
+    <p><img align="right" alt="" src="http://textpattern.com/favicon.ico" /></p>
+
+Self-closing tag endings in HTML5 doctype :
+  doctype: html5
+  input:  |
+    This is a multiline
+    text block split by
+    manual line breaks
+
+    - Multiline
+    - text block
+    - with dashes
+    - (not bullets)
+
+    !http://textpattern.com/favicon.ico!
+
+    !<http://textpattern.com/favicon.ico!
+
+    !>http://textpattern.com/favicon.ico!
+
+  expect : |
+    <p>This is a multiline<br>
+    text block split by<br>
+    manual line breaks</p>
+
+    <p>- Multiline<br>
+    - text block<br>
+    - with dashes<br>
+    - (not bullets)</p>
+
+    <p><img alt="" src="http://textpattern.com/favicon.ico"></p>
+
+    <p><img alt="" class="align-left" src="http://textpattern.com/favicon.ico"></p>
+
+    <p><img alt="" class="align-right" src="http://textpattern.com/favicon.ico"></p>
+

--- a/test/fixtures/issue-123.yaml
+++ b/test/fixtures/issue-123.yaml
@@ -8,11 +8,11 @@ HTM5 image alignment:
     !<10x10.gif!
 
   expect: |
-    <p><img alt="" class="align-right" height="10" src="10x10.gif" width="10" /></p>
+    <p><img alt="" class="align-right" height="10" src="10x10.gif" width="10"></p>
 
-    <p><img alt="" class="align-center" height="10" src="10x10.gif" width="10" /></p>
+    <p><img alt="" class="align-center" height="10" src="10x10.gif" width="10"></p>
 
-    <p><img alt="" class="align-left" height="10" src="10x10.gif" width="10" /></p>
+    <p><img alt="" class="align-left" height="10" src="10x10.gif" width="10"></p>
 
 XHTML image alignment:
   input: |

--- a/test/fixtures/issue-132.yaml
+++ b/test/fixtures/issue-132.yaml
@@ -13,11 +13,11 @@ Alignment is accepted in restricted mode when doctype is set to HTML5 :
     !<10x10.gif!
 
   expect: |
-    <p><img alt="" class="align-center" height="10" src="10x10.gif" width="10" /></p>
+    <p><img alt="" class="align-center" height="10" src="10x10.gif" width="10"></p>
 
-    <p><img alt="" class="align-right" height="10" src="10x10.gif" width="10" /></p>
+    <p><img alt="" class="align-right" height="10" src="10x10.gif" width="10"></p>
 
-    <p><img alt="" class="align-left" height="10" src="10x10.gif" width="10" /></p>
+    <p><img alt="" class="align-left" height="10" src="10x10.gif" width="10"></p>
 
 In XHTML same generates align attribute:
   setup:

--- a/test/fixtures/issue-180.yaml
+++ b/test/fixtures/issue-180.yaml
@@ -59,8 +59,8 @@ Alignment uses classes with HTML5:
 
     <p>Justified paragraph.</p>
 
-    <p><img alt="" class="align-left" src="1.jpg" /></p>
+    <p><img alt="" class="align-left" src="1.jpg"></p>
 
-    <p><img alt="" class="align-right" src="1.jpg" /></p>
+    <p><img alt="" class="align-right" src="1.jpg"></p>
 
-    <p><img alt="" class="align-center" src="1.jpg" /></p>
+    <p><img alt="" class="align-center" src="1.jpg"></p>


### PR DESCRIPTION
Currently Textile outputs self-closing tags such as `<br />` and `<img … />` tags using the trailing slash regardless of the doctype that is set. This is now flagged as an error by the W3C validator for the HTML5 doctype.

This mini-PR outputs self-closing (void) tags according to the doctype set:

- for XHTML: `<br />` and `<img … />` etc.
- for HTML5: `<br>` and `<img …>` etc.

### Type of change

- [x] Bug fix – just typos and consistent quotes
- [x] New feature
- [?] Breaking change
- [ ] Security fix

### Description

- New internal `getLineBreak()` function replaces hard-coded `<br />` instances.
- In the existing `newTag()` function, the self-closing ` />` syntax is only passed to Netcarver/Textile/Tag() when the doctype is not html5. This is a simpler solution than passing through the doctype as an attribute of Netcarver/Textile/Tag().

Other changes
- Minor typos in the descriptions and one quote inconsistency (in a separate commit)

Whether this is a breaking change is debatable. For existing XHTML doctype documents (which is still the default setting), the output is unchanged. For HTML5 doctypes the output is now different – but correct according to the validator – to how it was before. The output in the browser is unchanged.

### Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] I documented my additions and changes using PHPdoc.
- [x] I wrote fixtures to cover my additions.
- [ ] `$ composer update`
- [ ] `$ composer test`
- [ ] `$ composer cs`
